### PR TITLE
Add dynamic versioning to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     'Topic :: Software Development :: Libraries :: Python Modules'
 ]
 description-file = "README.md"
+dynamic = ["version"]
 
 [project.optional-dependencies]
 cli = [


### PR DESCRIPTION
Ref: https://github.com/PyO3/maturin/issues/1772

Lack of project.dynamic raises an error while building with uv.

```shellsession
~/prog/locloc master*
❯ uv -V
uv 0.11.8 (aarch64-linux-android)

~/prog/locloc master*
❯ uv sync
Resolved 48 packages in 1ms
  × Failed to download and build `pytokei==0.2.0`
  ├─▶ Failed to parse: `/data/data/com.termux/files/home/.cache/uv/sdists-v9/pypi/pytokei/0.2.0/aM5OWaE_IOXNuhDiYN6g9/src/pyproject.toml`
  ╰─▶ TOML parse error at line 5, column 1
        |
      5 | [project]
        | ^^^^^^^^^
      `pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither set nor present in the `project.dynamic` list

  help: `pytokei` (v0.2.0) was included because `locloc` (v0.1.3) depends on `pytokei`
```